### PR TITLE
CCANDLIB-14 Added JIRA link to README for issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 CheesecakeCEPASReader
 ========
+[![JIRA Issues](https://img.shields.io/badge/JIRA-Issues-blue)](https://jira.itachi1706.com:8123/browse/CCRANDLIB)
 
 This is my personal module for reading CEPAS cards based off FareBot
 


### PR DESCRIPTION
We are deprecating the issue section on GitHub and migrating it over to JIRA. This commit adds the JIRA issue link as we are unable to custom add a tab for JIRA here

Resolves CCANDLIB-14